### PR TITLE
Don't output an exception trace when piped into a process that stops reading

### DIFF
--- a/unidump/cli.py
+++ b/unidump/cli.py
@@ -179,7 +179,7 @@ def main(args: List[str] = None) -> int:
                     encoding=options.encoding,
                     lineformat=options.lineformat,
                     output=sys.stdout))
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, BrokenPipeError):
         sys.stdout.flush()
         return 1
     else:


### PR DESCRIPTION
Thank you for unidump! I recently came across it and have found it very useful.

My only issue with it is the behavior when you pipe `unidump`'s output to a process that doesn't read all of it:
```
$ yes | unidump -n 1 | head -1
      0    0079    y
Traceback (most recent call last):
    [... 10 lines of traceback output omitted ...]
BrokenPipeError: [Errno 32] Broken pipe
```

I hope you'll agree that it would be better to silently exit on `BrokenPipeError`, in the way that `KeyboardInterrupt` is already handled.